### PR TITLE
tweak: add custom event emitter and remove imported class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "krystal-crumbs",
       "version": "0.1.1",
       "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0"
-      },
       "devDependencies": {
         "@babel/cli": "^7.13.10",
         "@babel/core": "^7.13.10",
@@ -7651,6 +7648,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -23695,7 +23693,8 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true
     },
     "eventsource": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^3.11.2"
   },
-  "dependencies": {
-    "events": "^3.3.0"
-  },
   "jest": {
     "moduleFileExtensions": [
       "js",

--- a/src/components/eventEmitter.js
+++ b/src/components/eventEmitter.js
@@ -1,0 +1,25 @@
+class EventEmitter {
+  constructor() {
+    this.events = {};
+  }
+
+  on(eventName, callback) {
+    if (typeof this.events[eventName] !== "object") {
+      this.events[eventName] = [];
+    }
+    this.events[eventName].push(callback);
+  }
+
+  emit(event, ...args) {
+    let listeners;
+    if (typeof this.events[event] === "object") {
+      listeners = this.events[event].slice();
+
+      listeners.forEach((listener) => {
+        listener.apply(this, args);
+      });
+    }
+  }
+}
+
+export { EventEmitter };

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from "./components/eventEmitter";
 import { editScreen } from "./components/editScreen";
 import { cookieBanner } from "./components/cookieBanner";
 import "./main.css";
@@ -22,7 +22,7 @@ class Crumbs extends EventEmitter {
     if (!this.getCookie(this.cookieName)) {
       // Create the banner itself as a template literal and add it
       // to the DOM, at the end of the body
-      document.body.insertAdjacentHTML("beforeend", cookieBanner);
+      document.body.insertAdjacentHTML("afterbegin", cookieBanner);
 
       // As we have created this we can have access to it now for removing later
       this.banner = document.querySelector(".crumbs-banner");


### PR DESCRIPTION
Instead of using the EventEmitter class from the npm 'events' package we can use a custom implementation in order to minimise dependencies.

Note: this also updates the place where the cookie banner is inserted on initial page load. After some research it became clear that the original banner should be one of the first things after the `<body>` tag so that it is easily reachable by keyboard users as well as people utilising a screen reader.