### PR TITLE
tweak: Add configuration options for banner and edit dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ When the cookie preferences are saved our custom GTM event triggers a check of w
 
 If we follow through with our above example and say that we accept the 'functional' and 'analytical' cookie types but reject the 'live chat' option then the cookie value will be:
 
-| Name        | Value                   |
-| ----------- | ----------------------- |
-| cookie_name | v1\|true\|true\|false\| |
+| Name        | Value                 |
+| ----------- | --------------------- |
+| cookie_name | v1\|true\|true\|false |
 
 And our check for the analytics cookie type in GTM will be:
 
@@ -182,6 +182,6 @@ These are as follows:
 }
 ```
 
-You can import the Crumbs stylesheet with the following snippet:
+You can import the minified Crumbs stylesheet with the following snippet:
 
 `import "krystal-crumbs/dist/main.css"`

--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ There are a number of options that are required for the Crumbs constructor.
 
 | Option           | Description                                                                                                              | Type        | Required | Default Value    |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------- | -------- | ---------------- |
+| banner           | An object containing both a title and description property for the Crumbs banner                                         | object      | Yes      | -                |
 | cookieName       | The name you would like the give the cookie                                                                              | string      | No       | 'cookie_consent' |
 | days             | The duration of the cookie that is set on acceptance                                                                     | number      | Yes      | -                |
 | domain           | The domain you wish to set the cookie on                                                                                 | string      | Yes      | -                |
+| editBanner       | An object containing both a title and description property for the edit dialog                                           | object      | Yes      | -                |
 | editCookieButton | This is an HTMLElement that you want to attach an event listener too in order for the user to change the cookie settings | HTMLElement | Yes      | -                |
-| types            | An array of objects with each one containing an `identifier`, `summary`, `required` and a `title`                        | object[]    | Yes      | -                |
+| types            | An array of objects with each one containing an `identifier`, `summary`, `required` and a `title`                        | Type[]      | Yes      | -                |
 
-A `type` itself is made up of the following items
+A `Type` itself is made up of the following items
 
 | Option     | Description                                                                                                | Type    | Example                                                       |
 | ---------- | ---------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------- |
@@ -57,15 +59,15 @@ A `type` itself is made up of the following items
 
 Crumbs returns a stringed array of the type cookies that are to be set which are defined by passing in objects to the `types` array.
 
-Behind the scenes Crumbs then sets cookies based on the action of the user. For example, if 'Accept all Cookies' is clicked then Crumbs will set all of the `types` passed to `true`. This will results in the following cookie being set in the browser.
+Behind the scenes Crumbs then sets cookies based on the action of the user. For example, if 'Accept all Cookies' is clicked then Crumbs will set all of the `types` passed to `true`. This results in the following cookie being set in the browser.
 
-Note: This assumes that you have passed an array of length 3 to the `types` options.
+Note: This assumes that you have passed an array of length 3 to the `types` option.
 
 | Name           | Value                |
 | -------------- | -------------------- |
 | cookie_consent | v1\|true\|true\|true |
 
-After acceptance the `onSave` event is fired which will provide you with a list of the cookie types that
+After acceptance, the `onSave` event is fired which will provide you with a list of the cookie types that
 have been accepted.
 
 ```
@@ -88,8 +90,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const editButton = document.querySelector('.edit-cookies');
 
   const cookies = new Crumbs({
+    banner: {
+      title: 'We use cookies',
+      description: 'Your cookie banner description which should probably include a link to your privacy policy'
+    },
     cookieName: 'cookie_name',
     domain: 'domain.com',
+    editBanner: {
+      title: 'Edit cookie settings',
+      description: 'An explanation of why certain categories of cookies are set'
+    },
     editCookieButtons: editButton,
     days: 365,
     types: [

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ cookies.on('onSave', () => {
 
 When the cookie preferences are saved our custom GTM event triggers a check of what cookies have been set via a Regex table check against the different types that were provided to Crumbs.
 
-If we follow through with our above example and say that we accept the 'functional' and 'analytical' cookie types then the cookie being set will be:
+If we follow through with our above example and say that we accept the 'functional' and 'analytical' cookie types but reject the 'live chat' option then the cookie value will be:
 
 | Name        | Value                   |
 | ----------- | ----------------------- |
@@ -154,7 +154,7 @@ If we follow through with our above example and say that we accept the 'function
 
 And our check for the analytics cookie type in GTM will be:
 
-`^v1\|(true|false)\|**true**\|(true|false)$`
+`^v1\|(true|false)\|true\|(true|false)$`
 
 Given this information we can then go ahead and start to call any sort of analytics scripts that required this sort of consent.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Crumbs
 
-A small package that will determine which cookies a user is willing to accept.
-
-## Prerequesites
-
-Node > 10.13
+Crumbs is a small JavaScript library which allows you to declare what types of cookies your site/application
+uses and provides a list of the accepted categories.
 
 ## Installation and developing locally
 
@@ -26,10 +23,14 @@ These are accessed by calling the `onSave` method after instantiation.
 ```
 document.addEventListener('DOMContentLoaded', () => {
 
-  const cookies = new Crumbs();
-  cookies.on('onSave', (preferences) => {
-    // Do some stuff
+  const cookies = new Crumbs({
+    // options here
   });
+
+  cookies.on('onSave', (preferences) => {
+    // Do something with the preferences
+  });
+
 });
 ```
 
@@ -52,17 +53,19 @@ A `type` itself is made up of the following items
 | identifier | The unique name of the type of cookie                                                                      | string  | 'functional'                                                  |
 | required   | A boolean on whether or not this type of cookie is 100% needed for your site/application to be operational | boolean | true                                                          |
 | summary    | An explanation about the type of cookie you are allowing the user to set and why these are being used      | string  | 'A summary of what this type of cookie provides functionally' |
-| title      | A capitalised version of the `identifier` that is used as the heading on the edit dialog popup             | string  | 'Functional'                                                  |
+| title      | A capitalised version of the `identifier` that is used as the heading as part of the edit dialog           | string  | 'Functional'                                                  |
 
-**Example**
+### Example
 
 ```
 document.addEventListener('DOMContentLoaded', () => {
 
+  const editButton = document.querySelector('.edit-cookies');
+
   const cookies = new Crumbs({
     cookieName: 'cookie_name',
-    domain: '.domain.com',
-    editCookieButtons: document.querySelector('.edit-cookies'),
+    domain: 'domain.com',
+    editCookieButtons: editButton,
     days: 365,
     types: [
       {

--- a/README.md
+++ b/README.md
@@ -5,30 +5,21 @@ uses and provides a list of the accepted categories.
 
 ## Table of Contents
 
-1. [Installation and developing locally](#installation-and-developing-locally)
-2. [Production Build](#build)
-3. [Usage](#usage)
-4. [Options](#options)
-5. [Example](#example)
+1. [Setup](#setup)
+2. [Options](#options)
+3. [Example](#example)
 
    i. [Google Tag Manager](#google-tag-manager)
 
-6. [Styling](#styling)
+4. [Styling](#styling)
+5. [Developing locally](#developing-locally)
+6. [Production Build](#build)
 
-## Installation and developing locally
-
-1. Clone the repo via `git clone git@github.com:krystal/crumbs.git`
-2. `npm install`
-3. `npm run dev` to start the deveopment server.
-4. Visit [http://localhost:3000](http://localhost:3000)
-
-## Build
-
-`npm run build` will create the minified bundle in the `dist` folder
-
-## Usage
+## Setup
 
 The easiest way to get up and running with Crumbs is to install the package via [npm](https://www.npmjs.com/package/krystal-crumbs).
+
+`npm install krystal-crumbs`
 
 After installation you can then import Crumbs:
 
@@ -47,13 +38,13 @@ const cookies = new Crumbs({
 
 There are a number of options that are required for the Crumbs constructor.
 
-| Option           | Description                                                                                                              | Type        |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| cookieName       | The name you would like the give the cookie                                                                              | string      |
-| days             | The duration of the cookie that is set on acceptance                                                                     | number      |
-| domain           | The domain you wish to set the cookie on                                                                                 | string      |
-| editCookieButton | This is an HTMLElement that you want to attach an event listener too in order for the user to change the cookie settings | HTMLElement |
-| types            | An array of objects with each one containing a `identifier`, `summary`, `required` and a `title`                         | object[]    |
+| Option           | Description                                                                                                              | Type        | Required | Default Value    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------- | -------- | ---------------- |
+| cookieName       | The name you would like the give the cookie                                                                              | string      | No       | 'cookie_consent' |
+| days             | The duration of the cookie that is set on acceptance                                                                     | number      | Yes      | -                |
+| domain           | The domain you wish to set the cookie on                                                                                 | string      | Yes      | -                |
+| editCookieButton | This is an HTMLElement that you want to attach an event listener too in order for the user to change the cookie settings | HTMLElement | Yes      | -                |
+| types            | An array of objects with each one containing an `identifier`, `summary`, `required` and a `title`                        | object[]    | Yes      | -                |
 
 A `type` itself is made up of the following items
 
@@ -68,11 +59,11 @@ Crumbs returns a stringed array of the type cookies that are to be set which are
 
 Behind the scenes Crumbs then sets cookies based on the action of the user. For example, if 'Accept all Cookies' is clicked then Crumbs will set all of the `types` passed to `true`. This will results in the following cookie being set in the browser.
 
-Note: This assumes that you have passed an array of length 3 to the types options.
+Note: This assumes that you have passed an array of length 3 to the `types` options.
 
-| Name           | Value                  |
-| -------------- | ---------------------- |
-| cookie_consent | v1\|true\|true\|true\| |
+| Name           | Value                |
+| -------------- | -------------------- |
+| cookie_consent | v1\|true\|true\|true |
 
 After acceptance the `onSave` event is fired which will provide you with a list of the cookie types that
 have been accepted.
@@ -185,3 +176,14 @@ These are as follows:
 You can import the minified Crumbs stylesheet with the following snippet:
 
 `import "krystal-crumbs/dist/main.css"`
+
+## Developing locally
+
+1. Clone the repo via `git clone git@github.com:krystal/crumbs.git`
+2. `npm install`
+3. `npm run dev` to start the deveopment server.
+4. Visit [http://localhost:3000](http://localhost:3000)
+
+## Build
+
+`npm run build` will create the minified bundle in the `dist` folder

--- a/src/components/cookieBanner.js
+++ b/src/components/cookieBanner.js
@@ -1,8 +1,8 @@
-export const cookieBanner = `
-  <div class="crumbs-banner">
+export const cookieBanner = ({ title, description }) => {
+  return `<div class="crumbs-banner">
     <div class="crumbs-banner__content">
-      <h4 class="crumbs-banner__title">We use cookies</h4>
-      <p class="crumbs-banner__description">By clicking “Accept all cookies”, you agree to the storing of cookies on your device to enhance site navigation, analyse site usage, and assist in our marketing efforts. <a href="/privacy">Cookie Policy</a></p>
+      <h4 class="crumbs-banner__title">${title}</h4>
+      <p class="crumbs-banner__description">${description}</p>
     </div>
     <div>
       <button class="crumbs-button crumbs-edit-settings">Choose cookies</button>
@@ -10,3 +10,4 @@ export const cookieBanner = `
     </div>
   </div>
 `;
+};

--- a/src/components/editScreen.js
+++ b/src/components/editScreen.js
@@ -1,18 +1,20 @@
-export const editScreen = `
-  <div class="crumbs-edit" role="dialog" aria-labelledby="crumbs-dialog-title" aria-describedby="crumbs-dialog-descrption" tabindex="0">
-    <div class="crumbs-edit__content">
-      <div class="crumbs-edit__container">
-        <h3 id="crumbs-dialog-title" class="crumbs-edit__title">Edit cookie settings</h3>
-        <p id="crumbs-dialog-description" class="crumbs-edit__description">There are a number of cookies we need to use in order for our website to work properly. These cannot be disabled. However, you can disable non-essential cookies for the third-party services we use to help us provide better customer support, measure the performance of this website and run more effective marketing campaigns.</p>
-        <div id="cookie-categories"></div>
+export const editScreen = ({ title, description }) => {
+  return `
+    <div class="crumbs-edit" role="dialog" aria-labelledby="crumbs-dialog-title" aria-describedby="crumbs-dialog-descrption" tabindex="0">
+      <div class="crumbs-edit__content">
+        <div class="crumbs-edit__container">
+          <h3 id="crumbs-dialog-title" class="crumbs-edit__title">${title}</h3>
+          <p id="crumbs-dialog-description" class="crumbs-edit__description">${description}</p>
+          <div id="cookie-categories"></div>
+        </div>
       </div>
+      <div class="crumbs-edit__cta">
+        <button class="crumbs-button crumbs-edit-accept">Set cookie preferences</button>
+      </div>
+      <button class="crumbs-edit-close">
+        <span class="crumbs__hidden">Close cookie settings</span>
+        <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" aria-hidden="true" focusable="false"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
+      </button>
     </div>
-    <div class="crumbs-edit__cta">
-      <button class="crumbs-button crumbs-edit-accept">Set cookie preferences</button>
-    </div>
-    <button class="crumbs-edit-close">
-      <span class="crumbs__hidden">Close cookie settings</span>
-      <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" aria-hidden="true" focusable="false"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
-    </button>
-  </div>
-`;
+  `;
+};

--- a/src/main.css
+++ b/src/main.css
@@ -1,7 +1,8 @@
 :root {
   --crumbs-edit-bg: #f4f4f4;
   --crumbs-edit-overlay: rgba(0, 0, 0, 0.4);
-  --crumbs-edit-cta-bg: gainsboro;
+  --crumbs-edit-cta-bg: #dcdcdc;
+  --crumbs-toggle-bg-color: #ffffff;
   --crumbs-toggle-switch-bg: #858585;
   --crumbs-toggle-checked-bg: #e0e0e0;
   --crumbs-toggle-border-color: #dddddd;
@@ -33,7 +34,7 @@
 
 .crumbs-overlay::before {
   background-color: var(--crumbs-edit-overlay);
-  content: '';
+  content: "";
   top: 0;
   left: 0;
   height: 100%;
@@ -148,9 +149,9 @@
 }
 
 .crumbs-toggle__checkbox::after {
-  background: #fff;
+  background: var(--crumbs-toggle-bg-color);
   border-radius: 24px;
-  content: '';
+  content: "";
   height: 25px;
   left: 5px;
   position: absolute;

--- a/src/main.js
+++ b/src/main.js
@@ -4,11 +4,21 @@ import { cookieBanner } from "./components/cookieBanner";
 import "./main.css";
 
 class Crumbs extends EventEmitter {
-  constructor({ cookieName, domain, days, editCookieButton, types }) {
+  constructor({
+    banner,
+    cookieName,
+    domain,
+    days,
+    editBanner,
+    editCookieButton,
+    types,
+  }) {
     super();
+    this.banner = banner;
     this.cookieName = cookieName || "cookie_consent";
     this.domain = domain;
     this.days = days;
+    this.editBanner = editBanner;
     this.editCookieButton = editCookieButton;
     this.types = types;
     this.render();
@@ -22,7 +32,8 @@ class Crumbs extends EventEmitter {
     if (!this.getCookie(this.cookieName)) {
       // Create the banner itself as a template literal and add it
       // to the DOM, at the end of the body
-      document.body.insertAdjacentHTML("afterbegin", cookieBanner);
+      const banner = cookieBanner(this.banner);
+      document.body.insertAdjacentHTML("afterbegin", banner);
 
       // As we have created this we can have access to it now for removing later
       this.banner = document.querySelector(".crumbs-banner");
@@ -47,9 +58,10 @@ class Crumbs extends EventEmitter {
     }
 
     // This sets up the editScreen component and adds it to memory for later use
+    const editElement = editScreen(this.editBanner);
     const fragment = document
       .createRange()
-      .createContextualFragment(editScreen);
+      .createContextualFragment(editElement);
     const elementToAdd = fragment.firstElementChild;
     this.editScreen = elementToAdd;
 

--- a/src/main.js
+++ b/src/main.js
@@ -36,7 +36,7 @@ class Crumbs extends EventEmitter {
       document.body.insertAdjacentHTML("afterbegin", banner);
 
       // As we have created this we can have access to it now for removing later
-      this.banner = document.querySelector(".crumbs-banner");
+      this.cookieBanner = document.querySelector(".crumbs-banner");
 
       // Clicking on accept all sets all the cookies and hides the banner
       const acceptCookies = document.querySelector(".crumbs-accept-all");
@@ -46,7 +46,7 @@ class Crumbs extends EventEmitter {
         this.accepted = this.getCookieTypes(this.types);
 
         this.setAcceptanceCookie();
-        this.removeBanner(this.banner);
+        this.removeBanner(this.cookieBanner);
 
         this.emit("onSave", this.accepted);
       });
@@ -291,8 +291,8 @@ class Crumbs extends EventEmitter {
     this.editAcceptButton.removeEventListener("click", this.acceptance);
     document.removeEventListener("keydown", this.setFocusElements);
     this.removeBanner(this.editScreen);
-    if (this.banner) {
-      this.removeBanner(this.banner);
+    if (this.cookieBanner) {
+      this.removeBanner(this.cookieBanner);
     }
     this.emit("onSave", this.accepted);
     this.setAcceptanceCookie();


### PR DESCRIPTION
Adds the ability to pass a title and description to the initial cookie banner and the dialog window instead of hard coded values.

These updates have also been incorporated into the updates to the README.